### PR TITLE
Version 0.26.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  # skip: true  # [python_impl == 'pypy' and py==37]
   skip: True  # [py<38 or s390x]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,11 +22,11 @@ requirements:
     - setuptools
     - python
   run:
-    - certifi
-    - httpcore >=0.15.0,<0.16.0
-    - idna
     - python
-    - rfc3986 >=1.3,<2
+    - certifi
+    - httpcore ==1.*
+    - anyio
+    - idna
     - sniffio
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ build:
   skip: True  # [py<38 or s390x]
 
 requirements:
+  build:
+    - patch  # [unix]
+    - m2-patch  # [win]
   host:
     - pip
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,17 +21,21 @@ requirements:
     - m2-patch  # [win]
   host:
     - pip
-    - wheel
-    - setuptools
     - python
     - hatchling
   run:
     - python
     - certifi
-    - httpcore ==1.*
+    - httpcore >=1,<2
     - anyio
     - idna
     - sniffio
+  run_constrained:
+    - click >=8,<9
+    - pygment >=2,<3
+    - rich >=10,<14
+    - h2 >=3,<5
+    - socksio >=1,<2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "httpx" %}
-{% set version = "0.23.0" %}
+{% set version = "0.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef
+  sha256: 451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [python_impl == 'pypy' and py==37]
   skip: True  # [py<36 or s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,10 @@ about:
   license_family: BSD
   license_file: LICENSE.md
   summary: A next-generation HTTP client for Python.
+  description: |
+    HTTPX is a fully featured HTTP client library for Python 3.
+    It includes an integrated command line client, has support
+    for both HTTP/1.1 and HTTP/2, and provides both sync and async APIs.
   doc_url: https://www.encode.io/httpx/
   dev_url: https://github.com/encode/httpx
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,13 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf
-
+  patches:
+    - patches/0001-remove-fancy-pypi-readme.patch
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [python_impl == 'pypy' and py==37]
-  skip: True  # [py<36 or s390x]
+  # skip: true  # [python_impl == 'pypy' and py==37]
+  skip: True  # [py<38 or s390x]
 
 requirements:
   host:
@@ -21,6 +22,7 @@ requirements:
     - wheel
     - setuptools
     - python
+    - hatchling
   run:
     - python
     - certifi

--- a/recipe/patches/0001-remove-fancy-pypi-readme.patch
+++ b/recipe/patches/0001-remove-fancy-pypi-readme.patch
@@ -1,0 +1,38 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 4f7a848..ad75b7c 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["hatchling", "hatch-fancy-pypi-readme"]
++requires = ["hatchling"]
+ build-backend = "hatchling.build"
+ 
+ [project]
+@@ -73,26 +73,6 @@ include = [
+     "/tests",
+ ]
+ 
+-[tool.hatch.metadata.hooks.fancy-pypi-readme]
+-content-type = "text/markdown"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "README.md"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = "\n## Release Information\n\n"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "CHANGELOG.md"
+-pattern = "\n(###.+?\n)## "
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = "\n---\n\n[Full changelog](https://github.com/encode/httpx/blob/master/CHANGELOG.md)\n"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+-pattern = 'src="(docs/img/.*?)"'
+-replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'
+-
+ # https://beta.ruff.rs/docs/configuration/#using-rufftoml
+ [tool.ruff]
+ select = ["E", "F", "I", "B", "PIE"]


### PR DESCRIPTION
httpx 0.26.0

**Destination channel:** defaults

### Links

- [PKG-3953](https://anaconda.atlassian.net/browse/PKG-3953)
- [Upstream repository](https://github.com/encode/httpx)
- [Upstream changelog/diff](https://github.com/encode/httpx/blob/master/CHANGELOG.md)
- Relevant dependency PRs:
  - [PKG-3808](https://anaconda.atlassian.net/browse/PKG-3808)

### Explanation of changes:

- Update to 0.26.0
- Update dependencies
- Add patch that removes `hatch-fancy-pypi-readme`
- Linter fixes


[PKG-3953]: https://anaconda.atlassian.net/browse/PKG-3953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-3808]: https://anaconda.atlassian.net/browse/PKG-3808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ