### PR TITLE
httpx 0.27.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - anyio
     - idna
     - sniffio
+    - brotli
   run_constrained:
     - click >=8,<9
     - pygment >=2,<3
@@ -41,13 +42,58 @@ requirements:
     - h2 >=3,<5
     - socksio >=1,<2
 
+# We're not getting the same list but the same kinds errors are in
+# https://github.com/encode/httpx/discussions/2270
+{% set tests_to_skip = "test_asgi_headers[asyncio]" %}                                 # br
+{% set tests_to_skip = tests_to_skip + " or test_asgi_headers[trio]" %}                # br
+{% set tests_to_skip = tests_to_skip + " or test_brotli" %}                            # garbage chars
+{% set tests_to_skip = tests_to_skip + " or test_multi_with_identity" %}               # garbage chars
+{% set tests_to_skip = tests_to_skip + " or test_decoding_errors[br]" %}               # no httpx.DecodingError
+{% set tests_to_skip = tests_to_skip + " or test_help" %}                              # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_get" %}                               # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_json" %}                              # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_binary" %}                            # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_redirects" %}                         # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_follow_redirects" %}                  # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_post" %}                              # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_verbose" %}                           # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_auth" %}                              # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_download" %}                          # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_errors" %}                            # KeyError: 'prog_name'
+{% set tests_to_skip = tests_to_skip + " or test_raw_client_header" %}                 # br
+{% set tests_to_skip = tests_to_skip + " or test_event_hooks" %}                       # br
+{% set tests_to_skip = tests_to_skip + " or test_async_event_hooks[asyncio]" %}        # br
+{% set tests_to_skip = tests_to_skip + " or test_async_event_hooks[trio]" %}           # br
+{% set tests_to_skip = tests_to_skip + " or test_event_hooks_with_redirect" %}         # br
+{% set tests_to_skip = tests_to_skip + " or test_client_header" %}                     # br
+{% set tests_to_skip = tests_to_skip + " or test_header_merge" %}                      # br
+{% set tests_to_skip = tests_to_skip + " or test_header_merge_conflicting_headers" %}  # br
+{% set tests_to_skip = tests_to_skip + " or test_header_update" %}                     # br
+{% set tests_to_skip = tests_to_skip + " or test_remove_default_header" %}             # br
+{% set tests_to_skip = tests_to_skip + " or test_host_with_auth_and_port_in_url" %}    # br
+{% set tests_to_skip = tests_to_skip + " or test_host_with_non_default_port_in_url" %} # br
+{% set tests_to_skip = tests_to_skip + " or test_socks_proxy_deprecated" %}            # socksio
+{% set tests_to_skip = tests_to_skip + " or test_socks_proxy" %}                       # socksio
+{% set tests_to_skip = tests_to_skip + " or test_decode_error_with_request[br]" %}     # no httpx.DecodingError
+{% set tests_to_skip = tests_to_skip + " or test_value_error_without_request[br]" %}   # no httpx.DecodingError
+
 test:
+  source_files:
+    - tests
   imports:
     - httpx
   requires:
     - pip
+    - pytest
+    - brotli
+    - chardet
+    - trio
+    - trustme
+    - uvicorn
+    - h2
   commands:
     - pip check
+    - pytest -vv tests -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/encode/httpx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,11 +49,12 @@ requirements:
 #
 # no TypeError raised
 {% set tests_to_skip = tests_to_skip + " or test_multipart_encode_files_raises_exception_with_text_mode_file" %}  # [win]
-# no httpx.WriteTimeout
+# these two fail on assert response.elapsed > timedelta(seconds=0)
 {% set tests_to_skip = tests_to_skip + " or test_write_timeout[asyncio]" %}            # [win]
+{% set tests_to_skip = tests_to_skip + " or test_get[asyncio]" %}                      # [win]
 # paths with "\\\\" instead of "\\"
 {% set tests_to_skip = tests_to_skip + " or test_logging_ssl" %}                       # [win]
-# "tests\\test_utils.py" != "tests/test_utils.py"
+# again paths: "tests\\test_utils.py" != "tests/test_utils.py"
 {% set tests_to_skip = tests_to_skip + " or test_get_ssl_cert_file" %}                 # [win]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,7 @@ test:
     - rich
   commands:
     - pip check
+    - set PYTHONIOENCODING=utf8  # [win]
     - httpx --help
     - pytest -vv tests -k "not ({{ tests_to_skip }})"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "httpx" %}
-{% set version = "0.26.0" %}
+{% set version = "0.27.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,21 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf
+  sha256: a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5
   patches:
     - patches/0001-remove-fancy-pypi-readme.patch
+
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  # no httpcore>=1 for s390x
   skip: True  # [py<38 or s390x]
+  entry_points:
+    - httpx = httpx:main
 
 requirements:
   build:
-    - patch  # [unix]
+    - patch     # [unix]
     - m2-patch  # [win]
   host:
     - pip
@@ -55,7 +59,7 @@ about:
     HTTPX is a fully featured HTTP client library for Python 3.
     It includes an integrated command line client, has support
     for both HTTP/1.1 and HTTP/2, and provides both sync and async APIs.
-  doc_url: https://www.encode.io/httpx/
+  doc_url: https://www.python-httpx.org
   dev_url: https://github.com/encode/httpx
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,6 +77,10 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_decode_error_with_request[br]" %}     # no httpx.DecodingError
 {% set tests_to_skip = tests_to_skip + " or test_value_error_without_request[br]" %}   # no httpx.DecodingError
 
+{% set tests_to_skip = tests_to_skip + " or test_multipart_encode_files_raises_exception_with_text_mode_file" %}  # [win] no TypeError
+{% set tests_to_skip = tests_to_skip + " or test_write_timeout[asyncio]" %}            # [win] no httpx.WriteTimeout
+{% set tests_to_skip = tests_to_skip + " or test_logging_ssl" %}                       # [win] \\ -> \\\\ ?
+
 test:
   source_files:
     - tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - anyio
     - idna
     - sniffio
-    - brotli
   run_constrained:
     - click >=8,<9
     - pygment >=2,<3
@@ -44,12 +43,8 @@ requirements:
 
 # We're not getting the same list but the same kinds errors are in
 # https://github.com/encode/httpx/discussions/2270
-{% set tests_to_skip = "test_asgi_headers[asyncio]" %}                                 # br
-{% set tests_to_skip = tests_to_skip + " or test_asgi_headers[trio]" %}                # br
-{% set tests_to_skip = tests_to_skip + " or test_brotli" %}                            # garbage chars
-{% set tests_to_skip = tests_to_skip + " or test_multi_with_identity" %}               # garbage chars
-{% set tests_to_skip = tests_to_skip + " or test_decoding_errors[br]" %}               # no httpx.DecodingError
-{% set tests_to_skip = tests_to_skip + " or test_help" %}                              # KeyError: 'prog_name'
+{% set tests_to_skip = "" %}
+{% set tests_to_skip = tests_to_skip + " test_help" %}                              # KeyError: 'prog_name'
 {% set tests_to_skip = tests_to_skip + " or test_get" %}                               # KeyError: 'prog_name'
 {% set tests_to_skip = tests_to_skip + " or test_json" %}                              # KeyError: 'prog_name'
 {% set tests_to_skip = tests_to_skip + " or test_binary" %}                            # KeyError: 'prog_name'
@@ -60,23 +55,8 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_auth" %}                              # KeyError: 'prog_name'
 {% set tests_to_skip = tests_to_skip + " or test_download" %}                          # KeyError: 'prog_name'
 {% set tests_to_skip = tests_to_skip + " or test_errors" %}                            # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_raw_client_header" %}                 # br
-{% set tests_to_skip = tests_to_skip + " or test_event_hooks" %}                       # br
-{% set tests_to_skip = tests_to_skip + " or test_async_event_hooks[asyncio]" %}        # br
-{% set tests_to_skip = tests_to_skip + " or test_async_event_hooks[trio]" %}           # br
-{% set tests_to_skip = tests_to_skip + " or test_event_hooks_with_redirect" %}         # br
-{% set tests_to_skip = tests_to_skip + " or test_client_header" %}                     # br
-{% set tests_to_skip = tests_to_skip + " or test_header_merge" %}                      # br
-{% set tests_to_skip = tests_to_skip + " or test_header_merge_conflicting_headers" %}  # br
-{% set tests_to_skip = tests_to_skip + " or test_header_update" %}                     # br
-{% set tests_to_skip = tests_to_skip + " or test_remove_default_header" %}             # br
-{% set tests_to_skip = tests_to_skip + " or test_host_with_auth_and_port_in_url" %}    # br
-{% set tests_to_skip = tests_to_skip + " or test_host_with_non_default_port_in_url" %} # br
 {% set tests_to_skip = tests_to_skip + " or test_socks_proxy_deprecated" %}            # socksio
 {% set tests_to_skip = tests_to_skip + " or test_socks_proxy" %}                       # socksio
-{% set tests_to_skip = tests_to_skip + " or test_decode_error_with_request[br]" %}     # no httpx.DecodingError
-{% set tests_to_skip = tests_to_skip + " or test_value_error_without_request[br]" %}   # no httpx.DecodingError
-
 {% set tests_to_skip = tests_to_skip + " or test_multipart_encode_files_raises_exception_with_text_mode_file" %}  # [win] no TypeError
 {% set tests_to_skip = tests_to_skip + " or test_write_timeout[asyncio]" %}            # [win] no httpx.WriteTimeout
 {% set tests_to_skip = tests_to_skip + " or test_logging_ssl" %}                       # [win] \\ -> \\\\ ?
@@ -89,7 +69,9 @@ test:
   requires:
     - pip
     - pytest
-    - brotli
+    # You want brotli-python here rather than just the brotli that
+    # "import brotli" might imply
+    - brotli-python
     - chardet
     - trio
     - trustme

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,25 +41,20 @@ requirements:
     - h2 >=3,<5
     - socksio >=1,<2
 
-# We're not getting the same list but the same kinds errors are in
-# https://github.com/encode/httpx/discussions/2270
 {% set tests_to_skip = "" %}
-{% set tests_to_skip = tests_to_skip + " test_help" %}                              # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_get" %}                               # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_json" %}                              # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_binary" %}                            # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_redirects" %}                         # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_follow_redirects" %}                  # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_post" %}                              # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_verbose" %}                           # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_auth" %}                              # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_download" %}                          # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_errors" %}                            # KeyError: 'prog_name'
-{% set tests_to_skip = tests_to_skip + " or test_socks_proxy_deprecated" %}            # socksio
-{% set tests_to_skip = tests_to_skip + " or test_socks_proxy" %}                       # socksio
-{% set tests_to_skip = tests_to_skip + " or test_multipart_encode_files_raises_exception_with_text_mode_file" %}  # [win] no TypeError
-{% set tests_to_skip = tests_to_skip + " or test_write_timeout[asyncio]" %}            # [win] no httpx.WriteTimeout
-{% set tests_to_skip = tests_to_skip + " or test_logging_ssl" %}                       # [win] \\ -> \\\\ ?
+# skip tests using socksio, optional dependency, not available for all platforms
+{% set tests_to_skip = tests_to_skip + " test_socks_proxy_deprecated" %}               
+{% set tests_to_skip = tests_to_skip + " or test_socks_proxy" %}
+# skip some tests for Windows
+#
+# no TypeError raised
+{% set tests_to_skip = tests_to_skip + " or test_multipart_encode_files_raises_exception_with_text_mode_file" %}  # [win]
+# no httpx.WriteTimeout
+{% set tests_to_skip = tests_to_skip + " or test_write_timeout[asyncio]" %}            # [win]
+# paths with "\\\\" instead of "\\"
+{% set tests_to_skip = tests_to_skip + " or test_logging_ssl" %}                       # [win]
+# "tests\\test_utils.py" != "tests/test_utils.py"
+{% set tests_to_skip = tests_to_skip + " or test_get_ssl_cert_file" %}                 # [win]
 
 test:
   source_files:
@@ -77,8 +72,13 @@ test:
     - trustme
     - uvicorn
     - h2
+    # [cli testing] - pygment unavailable but optional
+    - click
+    # - pygment
+    - rich
   commands:
     - pip check
+    - httpx --help
     - pytest -vv tests -k "not ({{ tests_to_skip }})"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,16 +30,16 @@ requirements:
   run:
     - python
     - certifi
-    - httpcore >=1,<2
+    - httpcore >=1.0.0,<2.0.0a0
     - anyio
     - idna
     - sniffio
   run_constrained:
-    - click >=8,<9
-    - pygment >=2,<3
-    - rich >=10,<14
-    - h2 >=3,<5
-    - socksio >=1,<2
+    - click >=8.0.0,<9.0.0a0
+    - pygment >=2.0.0,<3.0.0a0
+    - rich >=10.0.0,<14.0.0a0
+    - h2 >=3.0.0,<5.0.0a0
+    - socksio >=1.0.0,<2.0.0a0
 
 {% set tests_to_skip = "" %}
 # skip tests using socksio, optional dependency, not available for all platforms
@@ -79,6 +79,11 @@ test:
     - rich
   commands:
     - pip check
+    # Running the command "httpx --help" from a Windows terminal works.
+    # PYTHONIOENCODING=utf8
+    # Solves 
+    #    "UnicodeEncodeError: 'charmap' codec can't encode character"
+    # during tests.
     - set PYTHONIOENCODING=utf8  # [win]
     - httpx --help
     - pytest -vv tests -k "not ({{ tests_to_skip }})"


### PR DESCRIPTION
httpx 0.27.0 

**Destination channel:** Defaults

### Links

- [PKG-5171]
- dev_url:        https://github.com/encode/httpx/tree/0.27.0
- conda_forge:    https://github.com/conda-forge/httpx-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/httpx/0.27.0
- pypi inspector: https://inspector.pypi.io/project/httpx/0.27.0

### Explanation of changes:

- basic build
- `brotli-python` is required to make the interfaces work (notably the tests)


[PKG-5171]: https://anaconda.atlassian.net/browse/PKG-5171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ