### PR TITLE
PKG-8116: httpx 0.23.0 py313 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [python_impl == 'pypy' and py==37]
   skip: True  # [py<36 or s390x]


### PR DESCRIPTION
httpx 0.23.0 

**Destination channel:** defaults

### Links

- [PKG-8116]() 
- [Upstream repository](https://github.com/encode/httpx)

### Explanation of changes:

- rebuild for py313


[PKG-8116]: https://anaconda.atlassian.net/browse/PKG-8116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ